### PR TITLE
Updated link again for example input file for the windwake problem.

### DIFF
--- a/doc/source/problems.rst
+++ b/doc/source/problems.rst
@@ -68,7 +68,7 @@ Windmill Wake Simulator
 :repository:  `GitHub <https://github.com/NREL/floris>`__
 :problem-key: ``windwake``
 :parameters:
-    --file   The path to the windpark/windmill specification. We recommend using `example_input.json <https://github.com/NREL/floris/blob/v2/examples/example_input.json>`__ from the FLORIS repository. (required)
+    --file   The path to the windpark/windmill specification. We recommend using `example_input.json <https://github.com/NREL/floris/blob/c98604593753def05086b54ce82f5551f01d2529/examples/example_input.json>`__ from the FLORIS repository. (required)
     -n   The number of windmills to be placed. (default: 3)
     -w   The width of the area in which the windmills are to be placed. (default: 333.33 * ``-n``)
     -h   The height of the area in which the windmills are to be placed. (default: 333.33 * ``-n``)


### PR DESCRIPTION
The link to the windwake json file broke again. This links directly to a commit, so should be more robust. 